### PR TITLE
tr(jenkins): replace deprecated ALT_DEPLOYMENT_REPOSITORY_TAG

### DIFF
--- a/infrastructure/buildVersion.groovy
+++ b/infrastructure/buildVersion.groovy
@@ -7,7 +7,7 @@ pipeline {
         stage('Build and deploy') {
             steps {
                 configFileProvider([configFile(fileId: 'maven-settings', variable: 'MAVEN_SETTINGS')]) {
-                    sh("./mvnw -s ${MAVEN_SETTINGS} --no-transfer-progress -B deploy -DskipTests -DaltDeploymentRepository=${env.ALT_DEPLOYMENT_REPOSITORY_TAG}")
+                    sh("./mvnw -s ${MAVEN_SETTINGS} --no-transfer-progress -B deploy -DskipTests -DaltDeploymentRepository=${env.ALT_DEPLOYMENT_REPOSITORY_STAGING}")
                 }
                 withCredentials([string(credentialsId: 'github-api', variable: 'GITHUB_API_TOKEN')]) {
                     sh "./infrastructure/upload-github-release-asset.sh github_api_token=$GITHUB_API_TOKEN tag=${params.version} filename=./community/target/bonita-admin-application-${params.version}.bos"


### PR DESCRIPTION
Jenkins global env var `ALT_DEPLOYMENT_REPOSITORY_TAG` is deprecated. `ALT_DEPLOYMENT_REPOSITORY_STAGING` is used instead.
