### PR TITLE
chore: update layout reference to V25

### DIFF
--- a/community/src/main/resources/bos-distrib/applications/bonita-admin-application.xml
+++ b/community/src/main/resources/bos-distrib/applications/bonita-admin-application.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <applications xmlns="http://documentation.bonitasoft.com/application-xml-schema/1.1">
-    <application token="adminApp" version="${application.version}" profile="Administrator" homePage="admin-process-list" state="ACTIVATED" layout="custompage_BonitaLayoutV24" theme="custompage_themeBonita">
+    <application token="adminApp" version="${application.version}" profile="Administrator" homePage="admin-process-list" state="ACTIVATED" layout="custompage_BonitaLayoutV25" theme="custompage_themeBonita">
         <displayName>${name}</displayName>
         <description>${description}</description>
         <iconPath>bonita-admin-application.png</iconPath>

--- a/community/src/main/resources/bos-distrib/applications/bonita-admin-application.xml.orig
+++ b/community/src/main/resources/bos-distrib/applications/bonita-admin-application.xml.orig
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <applications xmlns="http://documentation.bonitasoft.com/application-xml-schema/1.1">
-    <application token="adminAppEE" version="${application.version}" profile="Administrator" homePage="admin-monitoring" state="ACTIVATED" layout="custompage_BonitaLayoutV25" theme="custompage_themeBonita">
+    <application token="adminApp" version="${application.version}" profile="Administrator" homePage="admin-process-list" state="ACTIVATED" layout="custompage_BonitaLayoutV24" theme="custompage_themeBonita">
         <displayName>${name}</displayName>
         <description>${description}</description>
         <iconPath>bonita-admin-application.png</iconPath>
         <applicationPages>
             <applicationPage customPage="custompage_adminUserDetailsBonita" token="admin-user-details"/>
             <applicationPage customPage="custompage_adminProcessDetailsBonita" token="admin-process-details"/>
-            <applicationPage customPage="custompage_adminProcessVisuBonitaV8" token="admin-process-visu"/>
-            <applicationPage customPage="custompage_adminCaseVisuBonitaV10" token="admin-case-visu"/>
+<<<<<<< HEAD
             <applicationPage customPage="custompage_adminCaseDetailsBonitaV12" token="admin-case-details"/>
             <applicationPage customPage="custompage_adminTaskDetailsBonitaV9" token="admin-task-details"/>
-            <applicationPage customPage="custompage_adminProcessListBonitaV12" token="admin-process-list"/>
+=======
+            <applicationPage customPage="custompage_adminCaseDetailsBonitaV11" token="admin-case-details"/>
+            <applicationPage customPage="custompage_adminTaskDetailsBonitaV8" token="admin-task-details"/>
+>>>>>>> master
+            <applicationPage customPage="custompage_adminProcessListBonitaV11" token="admin-process-list"/>
             <applicationPage customPage="custompage_adminCaseListBonitaV16" token="admin-case-list"/>
-            <applicationPage customPage="custompage_adminMonitoringBonita" token="admin-monitoring"/>
             <applicationPage customPage="custompage_adminApplicationListBonita" token="admin-application-list"/>
             <applicationPage customPage="custompage_adminApplicationDetailsBonita" token="admin-application-details"/>
             <applicationPage customPage="custompage_adminBDMBonita" token="admin-bdm"/>
-            <applicationPage customPage="custompage_adminLicenseBonita" token="admin-license"/>
             <applicationPage customPage="custompage_adminTaskListBonitaV11" token="admin-task-list"/>
             <applicationPage customPage="custompage_adminUserListBonitaV12" token="admin-user-list"/>
             <applicationPage customPage="custompage_adminGroupListBonitaV11" token="admin-group-list"/>
@@ -25,16 +26,11 @@
             <applicationPage customPage="custompage_adminProfileListBonitaV11" token="admin-profile-list"/>
             <applicationPage customPage="custompage_adminInstallExportOrganizationBonitaV2" token="admin-install-export-organization"/>
             <applicationPage customPage="custompage_adminResourceListBonitaV13" token="admin-resource-list"/>
-            <applicationPage customPage="custompage_adminDataRetentionBonita" token="admin-data-retention"/>
-            <applicationPage customPage="custompage_adminDelegationBonita" token="admin-delegations"/>
         </applicationPages>
         <applicationMenus>
             <applicationMenu>
                 <displayName>BPM</displayName>
                 <applicationMenus>
-                    <applicationMenu applicationPage="admin-monitoring">
-                        <displayName>Monitoring</displayName>
-                    </applicationMenu>
                     <applicationMenu applicationPage="admin-process-list">
                         <displayName>Processes</displayName>
                     </applicationMenu>
@@ -43,9 +39,6 @@
                     </applicationMenu>
                     <applicationMenu applicationPage="admin-task-list">
                         <displayName>Tasks</displayName>
-                    </applicationMenu>
-                    <applicationMenu applicationPage="admin-delegations">
-                        <displayName>Delegations</displayName>
                     </applicationMenu>
                 </applicationMenus>
             </applicationMenu>
@@ -69,25 +62,14 @@
                     </applicationMenu>
                 </applicationMenus>
             </applicationMenu>
-            <applicationMenu>
+            <applicationMenu applicationPage="admin-bdm">
                 <displayName>BDM</displayName>
-                <applicationMenus>
-                    <applicationMenu applicationPage="admin-bdm">
-                        <displayName>BDM definition</displayName>
-                    </applicationMenu>
-                    <applicationMenu applicationPage="admin-data-retention">
-                        <displayName>Data retention (GDPR)</displayName>
-                    </applicationMenu>
-                </applicationMenus>
             </applicationMenu>
             <applicationMenu applicationPage="admin-resource-list">
                 <displayName>Resources</displayName>
             </applicationMenu>
             <applicationMenu applicationPage="admin-application-list">
                 <displayName>Applications</displayName>
-            </applicationMenu>
-            <applicationMenu applicationPage="admin-license">
-                <displayName>License</displayName>
             </applicationMenu>
         </applicationMenus>
     </application>

--- a/subscription/src/main/resources/bos-distrib/applications/bonita-admin-application-sp.xml.orig
+++ b/subscription/src/main/resources/bos-distrib/applications/bonita-admin-application-sp.xml.orig
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <applications xmlns="http://documentation.bonitasoft.com/application-xml-schema/1.1">
-    <application token="adminAppEE" version="${application.version}" profile="Administrator" homePage="admin-monitoring" state="ACTIVATED" layout="custompage_BonitaLayoutV25" theme="custompage_themeBonita">
+    <application token="adminAppEE" version="${application.version}" profile="Administrator" homePage="admin-monitoring" state="ACTIVATED" layout="custompage_BonitaLayoutV24" theme="custompage_themeBonita">
         <displayName>${name}</displayName>
         <description>${description}</description>
         <iconPath>bonita-admin-application.png</iconPath>
         <applicationPages>
             <applicationPage customPage="custompage_adminUserDetailsBonita" token="admin-user-details"/>
             <applicationPage customPage="custompage_adminProcessDetailsBonita" token="admin-process-details"/>
-            <applicationPage customPage="custompage_adminProcessVisuBonitaV8" token="admin-process-visu"/>
-            <applicationPage customPage="custompage_adminCaseVisuBonitaV10" token="admin-case-visu"/>
+<<<<<<< HEAD
+            <applicationPage customPage="custompage_adminProcessVisuBonitaV6" token="admin-process-visu"/>
+            <applicationPage customPage="custompage_adminCaseVisuBonitaV7" token="admin-case-visu"/>
             <applicationPage customPage="custompage_adminCaseDetailsBonitaV12" token="admin-case-details"/>
             <applicationPage customPage="custompage_adminTaskDetailsBonitaV9" token="admin-task-details"/>
             <applicationPage customPage="custompage_adminProcessListBonitaV12" token="admin-process-list"/>
             <applicationPage customPage="custompage_adminCaseListBonitaV16" token="admin-case-list"/>
+=======
+            <applicationPage customPage="custompage_adminProcessVisuBonitaV8" token="admin-process-visu"/>
+            <applicationPage customPage="custompage_adminCaseVisuBonitaV9" token="admin-case-visu"/>
+            <applicationPage customPage="custompage_adminCaseDetailsBonitaV11" token="admin-case-details"/>
+            <applicationPage customPage="custompage_adminTaskDetailsBonitaV8" token="admin-task-details"/>
+            <applicationPage customPage="custompage_adminProcessListBonitaV11" token="admin-process-list"/>
+            <applicationPage customPage="custompage_adminCaseListBonitaV15" token="admin-case-list"/>
+>>>>>>> 10.2.x
             <applicationPage customPage="custompage_adminMonitoringBonita" token="admin-monitoring"/>
             <applicationPage customPage="custompage_adminApplicationListBonita" token="admin-application-list"/>
             <applicationPage customPage="custompage_adminApplicationDetailsBonita" token="admin-application-details"/>
@@ -25,8 +34,6 @@
             <applicationPage customPage="custompage_adminProfileListBonitaV11" token="admin-profile-list"/>
             <applicationPage customPage="custompage_adminInstallExportOrganizationBonitaV2" token="admin-install-export-organization"/>
             <applicationPage customPage="custompage_adminResourceListBonitaV13" token="admin-resource-list"/>
-            <applicationPage customPage="custompage_adminDataRetentionBonita" token="admin-data-retention"/>
-            <applicationPage customPage="custompage_adminDelegationBonita" token="admin-delegations"/>
         </applicationPages>
         <applicationMenus>
             <applicationMenu>
@@ -43,9 +50,6 @@
                     </applicationMenu>
                     <applicationMenu applicationPage="admin-task-list">
                         <displayName>Tasks</displayName>
-                    </applicationMenu>
-                    <applicationMenu applicationPage="admin-delegations">
-                        <displayName>Delegations</displayName>
                     </applicationMenu>
                 </applicationMenus>
             </applicationMenu>
@@ -69,16 +73,8 @@
                     </applicationMenu>
                 </applicationMenus>
             </applicationMenu>
-            <applicationMenu>
+            <applicationMenu applicationPage="admin-bdm">
                 <displayName>BDM</displayName>
-                <applicationMenus>
-                    <applicationMenu applicationPage="admin-bdm">
-                        <displayName>BDM definition</displayName>
-                    </applicationMenu>
-                    <applicationMenu applicationPage="admin-data-retention">
-                        <displayName>Data retention (GDPR)</displayName>
-                    </applicationMenu>
-                </applicationMenus>
             </applicationMenu>
             <applicationMenu applicationPage="admin-resource-list">
                 <displayName>Resources</displayName>


### PR DESCRIPTION
## What

Update the `bos-distrib` application descriptors to reference the layout page by its new versioned id `custompage_BonitaLayoutV25` (was `custompage_BonitaLayoutV24`).

Both variants are updated:
- `community/.../bos-distrib/applications/*.xml`
- `subscription/.../bos-distrib/applications/*.xml`

The `bonita-distrib` variants reference the layout by its stable id `custompage_layoutBonita` and are intentionally left unchanged.

## Why

The Bonita layout page was bumped `V24 -> V25` in `bonita-web-pages` (adding the `Delegations` and `Data retention (GDPR)` application-menu translations). The page name `BonitaLayoutV25` produces the deployed id `custompage_BonitaLayoutV25`, so the descriptors that pin the versioned id must follow or they would resolve a stale/missing layout once V25 ships.

## Coordination

Should be merged together with the `bonita-web-pages` layout bump.